### PR TITLE
Handle API errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Yummly API Credentials
+YUMMLY_ID=xxxxxxxx
+YUMMLY_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 public/gen
+/.env

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Search:
       query: {
         q: 'chicken'
       }
-    }, function (error, response, json) {
+    }, function (error, statusCode, json) {
       if (error) {
         console.error(error);
-      } else if (response.statusCode === 200) {
+      } else if (statusCode === 200) {
         console.log(json);
       }
     });
@@ -39,14 +39,14 @@ Recipe:
       query: {
         q: 'pasta'
       }
-    }, function (error, response, json) {
+    }, function (error, statusCode, json) {
       if (error) {
         console.error(error);
-      } else if (response.statusCode === 200) {
+      } else if (statusCode === 200) {
         yummly.recipe({
           credentials: credentials,
           id: json.matches[0].id // id of the first recipe returned by search
-        }, function (error, response, json) {
+        }, function (error, statusCode, json) {
           if (error) {
             console.error(error);
           } else {

--- a/lib/yummly.js
+++ b/lib/yummly.js
@@ -26,7 +26,11 @@ function getJSON(options, callback) {
     }).on('data', function (data) {
       json += data;
     }).on('end', function (error) {
-      callback(error, response.statusCode, JSON.parse(json));
+      try {
+        callback(error, response.statusCode, JSON.parse(json));
+      } catch (e) {
+        callback(error, response.statusCode, { error: json });
+      }
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "npm": "1"
   },
   "devDependencies": {
+    "dotenv": "^4.0.0",
     "expect.js": "^0.3.1",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "npm": "1"
   },
   "devDependencies": {
-    "expect.js": "0.1.x",
-    "jshint": "0.5.x",
-    "mocha": "0.14.x"
+    "expect.js": "^0.3.1",
+    "jshint": "^2.9.4",
+    "mocha": "^3.2.0"
   },
 
   "licenses": [

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 global.expect = require('expect.js');
 
-global.yummly = require('lib/yummly');
+global.yummly = require('../lib/yummly');
 
 global.credentials = {
   id: '3cbb14d1',

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+require('dotenv').config();
+
 global.expect = require('expect.js');
 
 global.yummly = require('../lib/yummly');
 
 global.credentials = {
-  id: '3cbb14d1',
-  key: '6eed2ccd0ec397588fa29dfbe3becd78'
+  id: process.env.YUMMLY_ID || '3cbb14d1',
+  key: process.env.YUMMLY_API_KEY || '6eed2ccd0ec397588fa29dfbe3becd78'
 };

--- a/test/recipe.js
+++ b/test/recipe.js
@@ -36,7 +36,7 @@ describe('recipe', function () {
 
   it('should have calories', function () {
     expect(recipe.nutritionEstimates).to.be.an(Array);
-    expect(recipe.nutritionEstimates[0].attribute).to.equal('ENERC_KCAL');
+    expect(recipe.nutritionEstimates[0].attribute).to.equal('FAT_KCAL');
     console.log(recipe.nutritionEstimates[0].unit.plural + ':', recipe.nutritionEstimates[0].value);
   });
 

--- a/test/recipe.js
+++ b/test/recipe.js
@@ -54,4 +54,15 @@ describe('recipe', function () {
     console.log(recipe.images[0].hostedLargeUrl);
   });
 
+  it('should handle errors', function (done) {
+    yummly.recipe({
+      credentials: credentials,
+      id: 'Some-Missing-Recipe'
+    }, function (error, response, json) {
+      var expected = { error: 'No such recipe: Some-Missing-Recipe' };
+      expect(json).to.eql(expected);
+      done();
+    });
+  });
+
 });

--- a/test/search.js
+++ b/test/search.js
@@ -20,8 +20,8 @@ describe('search', function () {
     });
   });
 
-  it('should return 40 recipes', function () {
-    expect(search.matches.length).to.be(40);
+  it('should return 10 recipes', function () {
+    expect(search.matches.length).to.be(10);
   });
 
   it('should return recipe names', function () {


### PR DESCRIPTION
The API returns errors in plan text instead of JSON ([example link](http://api.yummly.com/v1/api/metadata/diet?_app_id=xxx&_app_key=xxx)), which causes `JSON.parse()` to throw an exception [here](https://github.com/yummly/node-yummly/blob/bbb4491bdf5148f145d1a4a53666728691c5034b/lib/yummly.js#L29). This PR catches these errors and returns them as JSON.